### PR TITLE
fix keystore Crypto field to smaller letter starting crypto

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ branches:
   except:
     - /^v[0-9]/
 install:
+  - yarn
   - yarn bootstrap
 script:
   - yarn test:src
@@ -21,3 +22,4 @@ deploy:
   keep-history: true
   on:
     branch: master
+

--- a/examples/import_keystore.js
+++ b/examples/import_keystore.js
@@ -1,0 +1,46 @@
+// import the Account class
+const { Account } = require('@harmony-js/account');
+
+// suppose we have an account
+const myPrivateKey = '0x831f0b3ff835d5ec4602878742fda25591b6d3bb2731366621ac83a05216bec8';
+const myAccountWithMyPrivateKey = new Account(myPrivateKey);
+
+// suppose we have a password, and we want to encrypt the account above
+const myStrongPassword = '123';
+
+async function encryptAndDecrypt(password) {
+  // we get the privateKey before encrypted as comparison
+  const unencryptedPrivateKey = myAccountWithMyPrivateKey.privateKey;
+
+  // export the account to keyStore string, which will make the privateKey encrpyted
+  const keyStoreFile = await myAccountWithMyPrivateKey.toFile(password);
+  // exported keyStoreFile
+  console.log({ keyStoreFile });
+  // see if the account is encrypted
+  console.log(`Is this account encrypted? \n ${myAccountWithMyPrivateKey.encrypted}`);
+  // keystore file should be equal to encrypted privateKey
+  console.log(
+    `Is privateKey equal to keyStore string? \n ${keyStoreFile ===
+      myAccountWithMyPrivateKey.privateKey}`,
+  );
+}
+
+// encryptAndDecrypt(myStrongPassword)
+
+// suppose we have keyStorefile, in this example, we just use same password and keystore string encrypted above
+const someKeyStoreFile =
+  '{"address":"1cc87010760602a576455d6d2f03a3bf92d2c2ca","crypto":{"cipher":"aes-128-ctr","ciphertext":"8bc4575478cae488a0f6d1b33ac72e61e0a04ce650aa7d03de26cfe6f6b0dce1","cipherparams":{"iv":"3bf838a3c67a4cbd6e02158f1ccd49d7"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"c8c5374b1ce08b25b7d5733f8d072396af6f93f4bf65c06efd29a7155c62883c"},"mac":"a9ad452817814e71a2af5571add57ee0d944d7ab63bf3a5cfaf66af53bb8b9b6"},"id":"ab8e578b-9431-47f6-9937-6f1f18e8f34f","version":3}';
+//'{"version":3,"id":"62326332-3139-4839-b534-656134623066","address":"1fe3da351d9fc0c4f02de5412ad7def8aee956c5","crypto":{"ciphertext":"b86ab81682c9f5a35738ad9bd38cd9b46c1b852ef33f16dd83068f79e20d5531","cipherparams":{"iv":"44efb5a514f34968e92cafad80566487"},"cipher":"aes-128-ctr","kdf":"scrypt","kdfparams":{"salt":"d70ae1f311601562113f98c8ebe382f52a332dca1588886e5ea91e2f8a647134","n":8192,"r":8,"p":1,"dklen":32},"mac":"7b63e4e31a75a22b7091291bb58302655b738539ef3e30b30a7a7f170f6163ef"}}'
+
+async function importKeyStoreFileAndDecrypt(keyStoreFile, password) {
+  // import keyStore string and provide the password, remember to make a new Account first
+  const importedAccount = await Account.new().fromFile(keyStoreFile, password);
+  // the account should decypted which `Account.encrypted` is false
+  console.log(`Is this account encrypted? \n ${importedAccount.encrypted}`);
+  // see if the privatekey is equal to unencrypted one?
+  console.log(
+    `Is the account recovered from keystore? \n ${importedAccount.privateKey === myPrivateKey}`,
+  );
+}
+
+importKeyStoreFileAndDecrypt(someKeyStoreFile, myStrongPassword);

--- a/examples/import_keystore.js
+++ b/examples/import_keystore.js
@@ -25,12 +25,11 @@ async function encryptAndDecrypt(password) {
   );
 }
 
-// encryptAndDecrypt(myStrongPassword)
+encryptAndDecrypt(myStrongPassword);
 
 // suppose we have keyStorefile, in this example, we just use same password and keystore string encrypted above
 const someKeyStoreFile =
-  '{"address":"1cc87010760602a576455d6d2f03a3bf92d2c2ca","crypto":{"cipher":"aes-128-ctr","ciphertext":"8bc4575478cae488a0f6d1b33ac72e61e0a04ce650aa7d03de26cfe6f6b0dce1","cipherparams":{"iv":"3bf838a3c67a4cbd6e02158f1ccd49d7"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"c8c5374b1ce08b25b7d5733f8d072396af6f93f4bf65c06efd29a7155c62883c"},"mac":"a9ad452817814e71a2af5571add57ee0d944d7ab63bf3a5cfaf66af53bb8b9b6"},"id":"ab8e578b-9431-47f6-9937-6f1f18e8f34f","version":3}';
-//'{"version":3,"id":"62326332-3139-4839-b534-656134623066","address":"1fe3da351d9fc0c4f02de5412ad7def8aee956c5","crypto":{"ciphertext":"b86ab81682c9f5a35738ad9bd38cd9b46c1b852ef33f16dd83068f79e20d5531","cipherparams":{"iv":"44efb5a514f34968e92cafad80566487"},"cipher":"aes-128-ctr","kdf":"scrypt","kdfparams":{"salt":"d70ae1f311601562113f98c8ebe382f52a332dca1588886e5ea91e2f8a647134","n":8192,"r":8,"p":1,"dklen":32},"mac":"7b63e4e31a75a22b7091291bb58302655b738539ef3e30b30a7a7f170f6163ef"}}'
+  '{"version":3,"id":"38326265-6165-4961-a338-353063643962","address":"1cc87010760602a576455d6d2f03a3bf92d2c2ca","crypto":{"ciphertext":"a4ee9120b27ba66fb9d3fabd6372fa3a11060cf439a6a1777ced1e6253de8c29","cipherparams":{"iv":"c18772a882ac461fffd1971e9ec57861"},"cipher":"aes-128-ctr","kdf":"scrypt","kdfparams":{"salt":"da4efedeca407279be65e02fc94b7c4b7c74c3396447c71e659c74a73a5d9131","n":8192,"r":8,"p":1,"dklen":32},"mac":"547ee6616dcdf424273c113ceb00728ccdda17ff6449f2cb84a1a8352c87b4e6"}}';
 
 async function importKeyStoreFileAndDecrypt(keyStoreFile, password) {
   // import keyStore string and provide the password, remember to make a new Account first

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "jest-json-schema": "^2.0.1",
     "jest-watch-typeahead": "^0.2.0",
     "jsdoc": "^3.6.3",
-    "lerna": "^3.2.1",
+    "lerna": "^3.20.2",
     "mkdirp": "^0.5.1",
     "prettier": "^1.18.2",
     "prettier-plugin-solidity": "^1.0.0-alpha.22",
@@ -126,7 +126,7 @@
     "tslint-config-prettier": "^1.15.0",
     "typedoc": "^0.15.0",
     "typedoc-plugin-markdown": "^2.1.0",
-    "typescript": "^3.2",
+    "typescript": "^3.8.3",
     "typescript-json-schema": "^0.36.0",
     "webpack": "^4.20.2",
     "webpack-command": "^0.4.1",
@@ -138,5 +138,8 @@
       "pre-commit": "pretty-quick --staged"
     }
   },
-  "name": "harmony-sdk-core"
+  "name": "harmony-sdk-core",
+  "dependencies": {
+    "tslib": "^1.11.1"
+  }
 }

--- a/packages/harmony-account/src/account.ts
+++ b/packages/harmony-account/src/account.ts
@@ -104,7 +104,7 @@ class Account {
 
   async fromFile(keyStore: string, password: string): Promise<Account> {
     try {
-      if (!password) {
+      if (typeof password !== 'string') {
         throw new Error('you must provide password');
       }
       const file: Keystore = JSON.parse(keyStore.toLowerCase());

--- a/packages/harmony-account/src/account.ts
+++ b/packages/harmony-account/src/account.ts
@@ -107,7 +107,7 @@ class Account {
       if (!password) {
         throw new Error('you must provide password');
       }
-      const file: Keystore = JSON.parse(keyStore);
+      const file: Keystore = JSON.parse(keyStore.toLowerCase());
       const decyptedPrivateKey = await decrypt(file, password);
       if (isPrivateKey(decyptedPrivateKey)) {
         return this._import(decyptedPrivateKey);

--- a/packages/harmony-crypto/src/keystore.ts
+++ b/packages/harmony-crypto/src/keystore.ts
@@ -58,9 +58,7 @@ export const encrypt = async (
   if (!isPrivateKey(privateKey)) {
     throw new Error('privateKey is not correct');
   }
-  // TODO: should use isString() to implement this
-
-  if (!password) {
+  if (typeof password !== 'string') {
     throw new Error('password is not found');
   }
   const address = getAddressFromPrivateKey(privateKey);
@@ -141,7 +139,7 @@ export const encryptPhrase = async (
   password: string,
   options?: EncryptOptions,
 ): Promise<string> => {
-  if (!password) {
+  if (typeof password !== 'string') {
     throw new Error('password is not found');
   }
   const salt = randomBytes(32);

--- a/packages/harmony-crypto/src/keystore.ts
+++ b/packages/harmony-crypto/src/keystore.ts
@@ -96,7 +96,7 @@ export const encrypt = async (
     version: 3,
     id: uuid.v4({ random: uuidRandom || hexToIntArray(randomBytes(16)) }),
     address: address.toLowerCase().replace('0x', ''),
-    Crypto: {
+    crypto: {
       ciphertext: ciphertext.toString('hex'),
       cipherparams: {
         iv: iv.toString('hex'),
@@ -116,15 +116,15 @@ export const encrypt = async (
  * @return {string} privateKey
  */
 export const decrypt = async (keystore: Keystore, password: string): Promise<string> => {
-  const ciphertext = Buffer.from(keystore.Crypto.ciphertext, 'hex');
-  const iv = Buffer.from(keystore.Crypto.cipherparams.iv, 'hex');
-  const { kdfparams } = keystore.Crypto;
+  const ciphertext = Buffer.from(keystore.crypto.ciphertext, 'hex');
+  const iv = Buffer.from(keystore.crypto.cipherparams.iv, 'hex');
+  const { kdfparams } = keystore.crypto;
 
-  const derivedKey = await getDerivedKey(Buffer.from(password), keystore.Crypto.kdf, kdfparams);
+  const derivedKey = await getDerivedKey(Buffer.from(password), keystore.crypto.kdf, kdfparams);
 
   const mac = keccak256(concat([derivedKey.slice(16, 32), ciphertext])).replace('0x', '');
 
-  if (mac.toUpperCase() !== keystore.Crypto.mac.toUpperCase()) {
+  if (mac.toUpperCase() !== keystore.crypto.mac.toUpperCase()) {
     return Promise.reject(new Error('Failed to decrypt.'));
   }
 
@@ -172,7 +172,7 @@ export const encryptPhrase = async (
   return JSON.stringify({
     version: 3,
     id: uuid.v4({ random: uuidRandom || hexToIntArray(randomBytes(16)) }),
-    Crypto: {
+    crypto: {
       ciphertext: ciphertext.toString('hex'),
       cipherparams: {
         iv: iv.toString('hex'),

--- a/packages/harmony-crypto/src/types.ts
+++ b/packages/harmony-crypto/src/types.ts
@@ -24,7 +24,7 @@ export interface EncryptOptions {
 
 export interface Keystore {
   address?: string;
-  Crypto: {
+  crypto: {
     cipher: string;
     cipherparams: {
       iv: string;

--- a/packages/harmony-network/package.json
+++ b/packages/harmony-network/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@harmony-js/utils": "0.1.35",
     "cross-fetch": "^3.0.2",
-    "mitt": "1.2.0",
+    "mitt": "^1.2.0",
     "websocket": "^1.0.28"
   },
   "gitHead": "775e2ba36924fcffd8d2c0b73587b549ed90bb81"


### PR DESCRIPTION
Ethereum wallet v3 format is small letters only,
and the sdk was using the field crypto as Cyrpto instead, causing incompatibility with keystores created from other sdks/cli.

Test file: `node examples/import_keystore.js`