### PR TITLE
[harmony-account] make getBalance return Balance interface instead of object

### DIFF
--- a/packages/harmony-account/src/account.ts
+++ b/packages/harmony-account/src/account.ts
@@ -30,6 +30,12 @@ import { Messenger, RPCMethod } from '@harmony-js/network';
 import { Shards } from './types';
 import { defaultMessenger } from './utils';
 
+export interface Balance {
+  balance?: string;
+  nonce?: number;
+  shardID?: number;
+}
+
 class Account {
   /**
    * static method create account
@@ -218,7 +224,7 @@ class Account {
    * });
    * ```
    */
-  async getBalance(blockNumber: string = 'latest'): Promise<object> {
+  async getBalance(blockNumber: string = 'latest'): Promise<Balance> {
     try {
       if (this.messenger) {
         const balance = await this.messenger.send(

--- a/packages/harmony-account/test/testAccount.test.ts
+++ b/packages/harmony-account/test/testAccount.test.ts
@@ -1,0 +1,25 @@
+/**
+ * @packageDocumentation
+ * @module harmony-transaction
+ * @ignore
+ */
+
+import { Account } from '../src/account';
+import { HttpProvider, Messenger } from '@harmony-js/network';
+import { ChainType, ChainID } from '@harmony-js/utils';
+
+const provider = new HttpProvider('http://localhost:9500');
+const messenger = new Messenger(provider, ChainType.Harmony, ChainID.HmyLocal);
+
+describe('test account', () => {
+  it('test Account.getBalance returns object that implements Balance interface', () => {
+    const acc = Account.new();
+    acc.setMessenger(messenger);
+    acc.getBalance().then((res) => {
+      expect(res).not.toBeNull();
+      expect(res.balance).not.toBeNull();
+      expect(res.nonce).not.toBeNull();
+      expect(res.shardID).not.toBeNull();
+    });
+  });
+});

--- a/packages/harmony-account/test/testAccount.test.ts
+++ b/packages/harmony-account/test/testAccount.test.ts
@@ -1,6 +1,6 @@
 /**
  * @packageDocumentation
- * @module harmony-transaction
+ * @module harmony-account
  * @ignore
  */
 


### PR DESCRIPTION
Account.getBalance returns `Promise<object>` which makes typescript raise error
`Property 'balance' does not exist on type 'object'`, hence changing it to `Balance` interface.