### PR TITLE
Abidecode

### DIFF
--- a/packages/harmony-contract/src/abi/abiCoder.ts
+++ b/packages/harmony-contract/src/abi/abiCoder.ts
@@ -197,8 +197,8 @@ const paramTypeArray = new RegExp(/^(.*)\[([0-9]*)\]$/);
 export const defaultCoerceFunc: CoerceFunc = (type: string, value: any): any => {
   const match = type.match(paramTypeNumber);
   if (match && parseInt(match[2], 10) <= 48) {
-    // return value.toNumber();
-    return value.toString('hex');
+    return value.toNumber();
+    //return value.toString('hex');
   }
   return value;
 };

--- a/packages/harmony-contract/src/methods/method.ts
+++ b/packages/harmony-contract/src/methods/method.ts
@@ -75,7 +75,7 @@ export class ContractMethod {
   }
   async call(options: any, blockNumber: any = 'latest') {
     try {
-      options = { ...this.contract.options, ...options };
+      options = { ...this.contract.options, data: this.encodeABI(), ...options };
       const shardID =
         options !== undefined && options.shardID !== undefined
           ? options.shardID

--- a/packages/harmony-crypto/src/keyTool.ts
+++ b/packages/harmony-crypto/src/keyTool.ts
@@ -9,7 +9,8 @@ import * as errors from './errors';
 
 import { keccak256 } from './keccak256';
 import { randomBytes } from './random';
-import { isPrivateKey, strip0x, isAddress } from '@harmony-js/utils';
+import { isPrivateKey, strip0x, isAddress, isBech32Address } from '@harmony-js/utils';
+import { fromBech32 } from './bech32';
 import { encode } from './rlp';
 
 const secp256k1 = elliptic.ec('secp256k1');
@@ -81,6 +82,9 @@ export const getAddressFromPublicKey = (publicKey: string): string => {
  * @return {string} checksumed address
  */
 export const toChecksumAddress = (address: string): string => {
+  if (typeof address === 'string' && isBech32Address(address)) {
+    address = fromBech32(address);
+  }
   if (typeof address !== 'string' || !address.match(/^0x[0-9A-Fa-f]{40}$/)) {
     errors.throwError('invalid address', errors.INVALID_ARGUMENT, {
       arg: 'address',


### PR DESCRIPTION
1. accept bech32 format address when encoding address
2. return number instead of string when decoding uint8...uint48
3. fixed bug that contract call always fails if contract.options.data not empty