### PR TITLE
Optionally resolve send transaction's promise before confirmation.

### DIFF
--- a/packages/harmony-contract/src/methods/method.ts
+++ b/packages/harmony-contract/src/methods/method.ts
@@ -43,13 +43,14 @@ export class ContractMethod {
           return { ...tx, ...params, gasLimit };
         });
 
+        const waitConfirm: boolean = params && params.waitConfirm === false ? false : true;
         const updateNonce: boolean = params && params.nonce !== undefined ? false : true;
         this.signTransaction(updateNonce).then((signed) => {
           this.sendTransaction(signed).then((sent) => {
             const [txn, id] = sent;
             this.transaction = txn;
             this.contract.transaction = this.transaction;
-            if (params.waitConfirm) {
+            if (waitConfirm) {
               this.confirm(id).then(() => {
                 this.transaction.emitter.resolve(this.contract);
               });

--- a/packages/harmony-contract/src/methods/method.ts
+++ b/packages/harmony-contract/src/methods/method.ts
@@ -49,9 +49,13 @@ export class ContractMethod {
             const [txn, id] = sent;
             this.transaction = txn;
             this.contract.transaction = this.transaction;
-            this.confirm(id).then(() => {
+            if (params.waitConfirm) {
+              this.confirm(id).then(() => {
+                this.transaction.emitter.resolve(this.contract);
+              });
+            } else {
               this.transaction.emitter.resolve(this.contract);
-            });
+            }
           });
         });
       };


### PR DESCRIPTION
Currently the promise is resolve once the transaction is confirmed.
The proposed changes will allow the user to chose if he wants to receive the response before the confirmation.