### PR TITLE
Fix Uncaught (in promise) User rejected sign transaction request

### DIFF
--- a/packages/harmony-contract/src/methods/method.ts
+++ b/packages/harmony-contract/src/methods/method.ts
@@ -58,6 +58,8 @@ export class ContractMethod {
               this.transaction.emitter.resolve(this.contract);
             }
           });
+        }).catch((error)=>{
+          this.transaction.emitter.resolve(this.contract);  
         });
       };
 


### PR DESCRIPTION
**Scenario**
When using .send method with contract method, popup sign transaction of chrome extension wallet will show.
But when user reject it (close popup or cancel this popup) we need to handle this event. 
**What expect**
Catch "User rejected sign transaction request" error when user reject sign transaction popup. 
**What happen**
Can not catch this error. 
Console log always show 
![image](https://user-images.githubusercontent.com/52391638/90047500-365aa180-dcfc-11ea-94de-b1e5fa95ef04.png)

**What this pull request do**
Throw error to catch