### PR TITLE
Start the topic count from 1.

### DIFF
--- a/packages/harmony-contract/src/abi/api.ts
+++ b/packages/harmony-contract/src/abi/api.ts
@@ -90,7 +90,7 @@ export class AbiCoderClass {
 
   decodeLog(inputs: any, data = '', topics: any) {
     const returnValues: any = {};
-    let topicCount = 0;
+    let topicCount = 1;
     let value;
     const nonIndexedInputKeys: any[] = [];
     const nonIndexedInputItems: any[] = [];


### PR DESCRIPTION
Topics array can contain up to 4 elements. The first element is always the event topic's signature. 