### PR TITLE
contract method imporvement 

### DIFF
--- a/packages/harmony-contract/src/contract.ts
+++ b/packages/harmony-contract/src/contract.ts
@@ -27,6 +27,8 @@ export class Contract {
   transaction?: Transaction;
   status: ContractStatus;
   shardID: number;
+  errorFunc: string = 'Error(string)';
+  errorFuncSig: string;
 
   constructor(
     abi: any = [],
@@ -47,6 +49,7 @@ export class Contract {
     this.runMethodFactory();
     this.runEventFactory();
     this.status = status;
+    this.errorFuncSig = this.abiCoder.encodeFunctionSignature(this.errorFunc);
     // tslint:disable-next-line: no-unused-expression
   }
   isInitialised() {

--- a/packages/harmony-contract/src/methods/method.ts
+++ b/packages/harmony-contract/src/methods/method.ts
@@ -50,7 +50,9 @@ export class ContractMethod {
             const [txn, id] = sent;
             this.transaction = txn;
             this.contract.transaction = this.transaction;
-            if (waitConfirm) {
+            if (this.transaction.isRejected()) {
+              this.transaction.emitter.reject(id); // in this case, id is error message
+            } else if (waitConfirm) {
               this.confirm(id).then(() => {
                 this.transaction.emitter.resolve(this.contract);
               });
@@ -87,22 +89,16 @@ export class ContractMethod {
           : this.contract.shardID;
       const nonce = '0x0';
 
-      let gasLimit: any;
-      // tslint:disable-next-line: prefer-conditional-expression
-      if (options !== undefined) {
+      let gasLimit: any = '21000000';
+      if (options !== undefined && (options.gas || options.gasLimit)) {
         gasLimit = options.gas || options.gasLimit;
-      } else {
-        gasLimit = '21000000';
       }
-      let from: string;
-      // tslint:disable-next-line: prefer-conditional-expression
-      if (this.wallet.signer) {
-        from = options && options.from ? options.from : this.wallet.signer.address;
-      } else {
-        from =
-          options && options.from ? options.from : '0x0000000000000000000000000000000000000000';
+      let from: string = this.wallet.signer
+        ? this.wallet.signer.address
+        : '0x0000000000000000000000000000000000000000';
+      if (options && options.from) {
+        from = options.from;
       }
-
       this.transaction = this.transaction.map((tx: any) => {
         return {
           ...tx,
@@ -320,7 +316,19 @@ export class ContractMethod {
 
   protected afterCall(response: any) {
     if (!response || response === '0x') {
-      return null;
+      throw { revert: response };
+    }
+    // length of `0x${methodSig}` is 2+4*2=10
+    if (response.length % 32 === 10 && response.startsWith(this.contract.errorFuncSig)) {
+      const errmsg = this.contract.abiCoder.decodeParameters(
+        [{ type: 'string' }],
+        '0x' + response.slice(10),
+      );
+      throw { revert: errmsg[0] };
+    }
+
+    if (this.methodKey === 'contractConstructor') {
+      return response;
     }
 
     const outputs = this.abiItem.getOutputs();

--- a/packages/harmony-contract/src/methods/method.ts
+++ b/packages/harmony-contract/src/methods/method.ts
@@ -315,9 +315,6 @@ export class ContractMethod {
   }
 
   protected afterCall(response: any) {
-    if (!response || response === '0x') {
-      throw { revert: response };
-    }
     // length of `0x${methodSig}` is 2+4*2=10
     if (response.length % 32 === 10 && response.startsWith(this.contract.errorFuncSig)) {
       const errmsg = this.contract.abiCoder.decodeParameters(
@@ -332,6 +329,14 @@ export class ContractMethod {
     }
 
     const outputs = this.abiItem.getOutputs();
+    if (outputs.length === 0) {
+      // if outputs is empty, we can't know the call is revert or not
+      return response;
+    }
+    if (!response || response === '0x') {
+      // if outputs isn't empty, treat it as revert
+      throw { revert: response };
+    }
     if (outputs.length > 1) {
       return this.contract.abiCoder.decodeParameters(outputs, response);
     }

--- a/packages/harmony-contract/src/methods/method.ts
+++ b/packages/harmony-contract/src/methods/method.ts
@@ -80,7 +80,7 @@ export class ContractMethod {
   }
   async call(options: any, blockNumber: any = 'latest') {
     try {
-      options = { ...this.contract.options, ...options };
+      options = { ...this.contract.options, data: this.transaction.txParams.data, ...options };
       const shardID =
         options !== undefined && options.shardID !== undefined
           ? options.shardID

--- a/packages/harmony-crypto/src/keyTool.ts
+++ b/packages/harmony-crypto/src/keyTool.ts
@@ -9,7 +9,8 @@ import * as errors from './errors';
 
 import { keccak256 } from './keccak256';
 import { randomBytes } from './random';
-import { isPrivateKey, strip0x, isAddress } from '@harmony-js/utils';
+import { isPrivateKey, strip0x, isAddress, isBech32Address } from '@harmony-js/utils';
+import { fromBech32 } from './bech32';
 import { encode } from './rlp';
 
 const secp256k1 = elliptic.ec('secp256k1');
@@ -81,6 +82,9 @@ export const getAddressFromPublicKey = (publicKey: string): string => {
  * @return {string} checksumed address
  */
 export const toChecksumAddress = (address: string): string => {
+  if (typeof address === 'string' && isBech32Address(address)) {
+    address = fromBech32(address);
+  }
   if (typeof address !== 'string' || !address.match(/^0x[0-9A-Fa-f]{40}$/)) {
     errors.throwError('invalid address', errors.INVALID_ARGUMENT, {
       arg: 'address',


### PR DESCRIPTION
1. accept ONE format address as a contract method argument
2. fixed a bug that contract method call always fails if contract.options.data not empty
3. handle revert message in contract call (not send). in rare case, it will treat normal return data as error message,  the perfect solution need node to return the EVM error.