### PR TITLE
fix broken e2e test

### DIFF
--- a/e2e/src/blockchain.e2e.ts
+++ b/e2e/src/blockchain.e2e.ts
@@ -1,4 +1,4 @@
-import {harmony} from './harmony';
+import { harmony } from './harmony';
 
 import demoAccounts from '../fixtures/testAccount.json';
 
@@ -30,23 +30,23 @@ describe('e2e test blockchain', () => {
     expect(harmony.utils.isHex(res.result)).toEqual(true);
   });
   it('should test hmy_getBlockByNumber', async () => {
-    const res = await bc.getBlockByNumber({blockNumber: 'latest'});
+    const res = await bc.getBlockByNumber({ blockNumber: 'latest' });
     const size = res.result.size;
     expect(res.responseType).toEqual('raw');
     expect(harmony.utils.isHex(size)).toEqual(true);
     expect(checkBlockData(res.result)).toEqual(true);
-    const res2 = await bc.getBlockByNumber({blockNumber: res.result.number});
+    const res2 = await bc.getBlockByNumber({ blockNumber: res.result.number });
     expect(res2.responseType).toEqual('raw');
     expect(harmony.utils.isHex(res2.result.size)).toEqual(true);
     expect(checkBlockData(res2.result)).toEqual(true);
-    const res3 = await bc.getBlockByNumber({returnObject: true});
+    const res3 = await bc.getBlockByNumber({ returnObject: true });
     expect(res3.responseType).toEqual('raw');
     expect(checkBlockData(res3.result)).toEqual(true);
   });
 
   it('should test hmy_getBlockByHash', async () => {
-    const latestBlock = await bc.getBlockByNumber({blockNumber: 'latest'});
-    const res = await bc.getBlockByHash({blockHash: latestBlock.result.hash});
+    const latestBlock = await bc.getBlockByNumber({ blockNumber: 'latest' });
+    const res = await bc.getBlockByHash({ blockHash: latestBlock.result.hash });
     expect(res.responseType).toEqual('raw');
     expect(latestBlock.result.hash).toEqual(res.result.hash);
     expect(harmony.utils.isHex(res.result.size)).toEqual(true);
@@ -55,7 +55,7 @@ describe('e2e test blockchain', () => {
 
   // account related
   it('should test hmy_getBalance', async () => {
-    const balance = await bc.getBalance({address: testAccount.Address});
+    const balance = await bc.getBalance({ address: testAccount.Address });
     expect(harmony.utils.isHex(balance.result)).toEqual(true);
   });
 });
@@ -71,7 +71,7 @@ function checkBlockData(data: any) {
       gasUsed: [harmony.utils.isHex],
       hash: [harmony.utils.isHash],
       logsBloom: [harmony.utils.isHex],
-      miner: [harmony.utils.isAddress],
+      miner: [harmony.utils.isBech32Address],
       mixHash: [harmony.utils.isHash],
       nonce: [harmony.utils.isNumber],
       number: [harmony.utils.isHex],
@@ -83,6 +83,6 @@ function checkBlockData(data: any) {
       transactionsRoot: [harmony.utils.isHash],
       uncles: [harmony.utils.isArray],
     },
-    {transactions: [harmony.utils.isArray]},
+    { transactions: [harmony.utils.isArray] },
   );
 }

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
-    "declarationDir": "dist"
+    "declarationDir": "dist",
+    "resolveJsonModule": true,
+    "esModuleInterop": true
   },
   "include": ["src", "../typings/**/*.d.ts", "fixtures"],
   "references": [


### PR DESCRIPTION
Before fix:

```
 FAIL  e2e/src/blockchain.e2e.ts
  e2e test blockchain
    ✓ should test net_peerCount (4ms)
    ✓ should test net_version (2ms)
    ✓ should test hmy_protocolVersion (1ms)
    ✓ should test hmy_blockNumber (2ms)
    ✕ should test hmy_getBlockByNumber (20ms)
    ✕ should test hmy_getBlockByHash (14ms)
    ✓ should test hmy_getBalance (6ms)

  ● e2e test blockchain › should test hmy_getBlockByNumber

    Validation failed for miner,should be validated by isAddress



      at Object.validateArgs (packages/harmony-utils/src/utils.ts:1104:17)
      at checkBlockData (e2e/src/blockchain.e2e.ts:64:24)
      at e2e/src/blockchain.e2e.ts:37:12
      at step (node_modules/tslib/tslib.js:141:27)
      at Object.next (node_modules/tslib/tslib.js:122:57)
      at fulfilled (node_modules/tslib/tslib.js:112:62)

  ● e2e test blockchain › should test hmy_getBlockByHash

    Validation failed for miner,should be validated by isAddress

      at Object.validateArgs (packages/harmony-utils/src/utils.ts:1104:17)
      at checkBlockData (e2e/src/blockchain.e2e.ts:64:24)
      at e2e/src/blockchain.e2e.ts:53:12
      at step (node_modules/tslib/tslib.js:141:27)
      at Object.next (node_modules/tslib/tslib.js:122:57)
      at fulfilled (node_modules/tslib/tslib.js:112:62)
```

After fix 
```
Test Suites: 3 passed, 3 total
Tests:       20 passed, 20 total
Snapshots:   0 total
Time:        17.543s
Ran all test suites.
✨  Done in 18.36s.
```