### PR TITLE
Expose the raw abi on the contract object

### DIFF
--- a/packages/harmony-contract/src/contract.ts
+++ b/packages/harmony-contract/src/contract.ts
@@ -20,6 +20,7 @@ import { ContractStatus } from './utils/status';
 export class Contract {
   methods: any;
   events: any;
+  abi: any = [];
   abiModel: any | AbiModel;
   abiCoder: AbiCoderClass;
   options: ContractOptions | any;
@@ -38,6 +39,7 @@ export class Contract {
     status: ContractStatus = ContractStatus.INITIALISED,
   ) {
     // super();
+    this.abi = abi;
     this.abiCoder = AbiCoder();
     this.abiModel = abiMapper(abi, this.abiCoder);
     this.options = options;


### PR DESCRIPTION
It would be super helpful if the raw ABI passed in to the contract can be accessed after the contract has been initialized.

This would make it easier to e.g. interact with Ethers.js (or other frameworks) for custom/advanced cases - which is something that happens a lot in the Uniswap/Swoop interface, e.g:

```
import { Interface } from '@ethersproject/abi'
const contractInterface = (contract) ? new Interface(contract.abi) : null; // contract is an instance of @harmony-js/contract
const fragment = useMemo(() => contractInterface?.getFunction(methodName), [contractInterface, methodName])
  const calls = useMemo<Call[]>(() => {
    return contract && contractInterface && fragment && isValidMethodArgs(inputs)
      ? [
          {
            address: contract.address,
            callData: contractInterface.encodeFunctionData(fragment, inputs)
          }
        ]
      : []
  }, [contract, contractInterface, fragment, inputs])

  const result = useCallsData(calls, options)[0]
```

Without having the `abi` accessible as a property, we'd have to rewrite the entire contract system in Uniswap to use a wrapper instead, resulting in a lot of extra work, complexities etc.

This PR simply adds `abi` as a property for Contract and assigns the abi constructor arg to it.

Tests:
```
$ yarn test:src
Test Suites: 13 passed, 13 total
Tests:       77 passed, 77 total
Snapshots:   0 total
Time:        133.707s
Ran all test suites.
✨  Done in 135.19s.
```