### PR TITLE
Fix OneWallet compatibility for nonces returned as numbers instead of hex

### DIFF
--- a/packages/harmony-core/src/harmonyExtension.ts
+++ b/packages/harmony-core/src/harmonyExtension.ts
@@ -182,7 +182,7 @@ export class HarmonyExtension {
           transaction.setParams({
             ...transaction.txParams,
             from: crypto.getAddress(extensionAccount.address).bech32,
-            nonce: Number.parseInt(utils.hexToNumber(nonce.result), 10),
+            nonce: Number.parseInt(utils.isHex(nonce.result.toString()) ? utils.hexToNumber(nonce.result.toString()) : nonce.result.toString(), 10),
           });
         } else {
           transaction.setParams({


### PR DESCRIPTION
OneWallet will not work for some dApps, e.g. Swoop, when `harmonyExtension.ts` tries to parse a number as a hex value.

Fix: check if the nonce is a hex value and only convert it if it is hex, otherwise perform no conversion.